### PR TITLE
[http://jira.ubiqube.com/browse/MARK-169] model id fixed

### DIFF
--- a/LINUX/K8S_CLI/.meta_k8s_cli_control.xml
+++ b/LINUX/K8S_CLI/.meta_k8s_cli_control.xml
@@ -23,7 +23,7 @@
         </entry>
         <entry>
             <key>MODEL</key>
-            <value>14020601</value>
+            <value>19112020</value>
         </entry>
         <entry>
             <key>MANUFACTURER</key>

--- a/LINUX/K8S_CLI/.meta_k8s_cni_install.xml
+++ b/LINUX/K8S_CLI/.meta_k8s_cni_install.xml
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>MODEL</key>
-            <value>14020601</value>
+            <value>19112020</value>
         </entry>
         <entry>
             <key>TAG</key>

--- a/LINUX/K8S_CLI/.meta_k8s_create_service_account.xml
+++ b/LINUX/K8S_CLI/.meta_k8s_create_service_account.xml
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>MODEL</key>
-            <value>14020601</value>
+            <value>19112020</value>
         </entry>
         <entry>
             <key>TAG</key>

--- a/LINUX/K8S_CLI/.meta_k8s_delete_node.xml
+++ b/LINUX/K8S_CLI/.meta_k8s_delete_node.xml
@@ -23,7 +23,7 @@
         </entry>
         <entry>
             <key>MODEL</key>
-            <value>14020601</value>
+            <value>19112020</value>
         </entry>
         <entry>
             <key>MANUFACTURER</key>

--- a/LINUX/K8S_CLI/.meta_k8s_get_key.xml
+++ b/LINUX/K8S_CLI/.meta_k8s_get_key.xml
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>MODEL</key>
-            <value>14020601</value>
+            <value>19112020</value>
         </entry>
         <entry>
             <key>TAG</key>

--- a/LINUX/K8S_CLI/.meta_k8s_get_token.xml
+++ b/LINUX/K8S_CLI/.meta_k8s_get_token.xml
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>MODEL</key>
-            <value>14020601</value>
+            <value>19112020</value>
         </entry>
         <entry>
             <key>TAG</key>

--- a/LINUX/K8S_CLI/.meta_k8s_ha_proxy.xml
+++ b/LINUX/K8S_CLI/.meta_k8s_ha_proxy.xml
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>MODEL</key>
-            <value>14020601</value>
+            <value>19112020</value>
         </entry>
         <entry>
             <key>TAG</key>

--- a/LINUX/K8S_CLI/.meta_k8s_join_master.xml
+++ b/LINUX/K8S_CLI/.meta_k8s_join_master.xml
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>MODEL</key>
-            <value>14020601</value>
+            <value>19112020</value>
         </entry>
         <entry>
             <key>TAG</key>

--- a/LINUX/K8S_CLI/.meta_k8s_join_worker.xml
+++ b/LINUX/K8S_CLI/.meta_k8s_join_worker.xml
@@ -23,7 +23,7 @@
         </entry>
         <entry>
             <key>MODEL</key>
-            <value>14020601</value>
+            <value>19112020</value>
         </entry>
         <entry>
             <key>MANUFACTURER</key>

--- a/LINUX/K8S_CLI/.meta_k8s_kubeadm_init.xml
+++ b/LINUX/K8S_CLI/.meta_k8s_kubeadm_init.xml
@@ -23,7 +23,7 @@
         </entry>
         <entry>
             <key>MODEL</key>
-            <value>14020601</value>
+            <value>19112020</value>
         </entry>
         <entry>
             <key>MANUFACTURER</key>

--- a/LINUX/K8S_CLI/.meta_k8s_package_management.xml
+++ b/LINUX/K8S_CLI/.meta_k8s_package_management.xml
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>MODEL</key>
-            <value>14020601</value>
+            <value>19112020</value>
         </entry>
         <entry>
             <key>TAG</key>

--- a/LINUX/K8S_CLI/.meta_k8s_pre_requirements.xml
+++ b/LINUX/K8S_CLI/.meta_k8s_pre_requirements.xml
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>MODEL</key>
-            <value>14020601</value>
+            <value>19112020</value>
         </entry>
         <entry>
             <key>TAG</key>


### PR DESCRIPTION
fix for MS required since new model was created for linux manufacturer

cat /opt/devops/OpenMSA_Adapters/adapters/linux_k8_cli/conf/sms_router.conf
# LINUX_GENERIC
model                                   14020601:19112020
report-model                            Linux
path                                    linux_generic
asset-script-name                       linux_generic_mgmt.php